### PR TITLE
fixed drawers stacking on top of each other

### DIFF
--- a/src/pages/Chat/components/InfoBar/ChatRoom.js
+++ b/src/pages/Chat/components/InfoBar/ChatRoom.js
@@ -73,6 +73,7 @@ export default function ChatRoom({ chatRoom, user, refetch }) {
       messageToggle ? setMessageToggle(false) : setMessageToggle(true)
     };
 
+
     return (
       <>
         <div className={classes.root}>
@@ -82,7 +83,8 @@ export default function ChatRoom({ chatRoom, user, refetch }) {
         <Drawer
           anchor = "right"
           open = {messageToggle}
-          variant = "persistent"
+          onClose={handleClick}
+          variant = "temporary"
           PaperProps = {{ style: { width: "66%" } }}>
           <div className={classes.titleDiv}>
             <h1 className={classes.roomTitle}>{participants}</h1>


### PR DESCRIPTION
Fixes drawers for chat messages stacking on each other

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?
- [x] User can click either the 'X' at the top right of the message or outside of the message to close the drawer
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] There are no merge conflicts
